### PR TITLE
Add slim child gene fields

### DIFF
--- a/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
@@ -76,8 +76,17 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     $sequence = $entity->data__sequence['und'][0]['value'];
 
     if (!$sequence) {
-      // TODO: We cant draw without a sequence.
-      // Now what?
+      $length = $entity->data__sequence_length['und'][0]['value'];
+      if (!$length) {
+        $length = '5000';
+      }
+      $sequence = '';
+      $i = 0;
+      while ($i < $length) {
+        $sequence .= 'N';
+        $i++;
+      }
+
     }
 
     $coordinates = $entity->data__sequence_coordinates['und'][0]['value'];

--- a/includes/TripalFields/local__child_annotations/local__child_annotations.inc
+++ b/includes/TripalFields/local__child_annotations/local__child_annotations.inc
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @class
+ * Purpose:
+ *
+ * Data:
+ * Assumptions:
+ */
+class local__child_annotations extends ChadoField {
+
+  public static $default_label = 'Child Annotations';
+  public static $default_description = 'All of the annotations associated with child features.';
+  public static $default_widget = 'local__child_annotations_widget';
+  public static $default_formatter = 'local__child_annotations_formatter';
+  public static $module = 'tripal_chado';
+  public static $default_settings = [
+    'storage' => 'field_chado_storage',
+    'searchable_keys' => [],
+  ];
+  public static $download_formatters = [
+    'TripalTabDownloader',
+    'TripalCSVDownloader',
+  ];
+  public static $default_instance_settings = [
+    // The DATABASE name, as it appears in chado.db.  This also builds the link-out url.  In most cases this will simply be the CV name.  In some cases (EDAM) this will be the SUBONTOLOGY.
+    'term_vocabulary' => 'local',
+    // The name of the term.
+    'term_name' => 'child_properties',
+    // The unique ID (i.e. accession) of the term.
+    'term_accession' => 'child_properties',
+    // Set to TRUE if the site admin is not allowed to change the term
+    // type, otherwise the admin can change the term mapped to a field.
+    'term_fixed' => FALSE,
+    // Indicates if this field should be automatically attached to display
+    // or web services or if this field should be loaded separately. This
+    // is convenient for speed.  Fields that are slow should for loading
+    // should have auto_attach set to FALSE so tha their values can be
+    // attached asynchronously.
+    'auto_attach' => FALSE,
+    // The table in Chado that the instance maps to.
+    'chado_table' => '',
+    // The column of the table in Chado where the value of the field comes from.
+    'chado_column' => '',
+    // The base table.
+    'base_table' => '',
+  ];
+
+  public static $no_ui = FALSE;
+  public static $no_data = FALSE;
+
+  /**
+   * @see ChadoField::load()
+   **/
+  public function load($entity) {
+    parent::load($entity);
+    //  We should load in the data here.
+    //  As a stopgap, we simply use the data loaded by the parent field in the formatter instead.
+    $entity->local__child_annotations['und'][0]['value'] = TRUE;
+
+  }
+
+  /**
+   * @see ChadoField::query()
+   **/
+  public function query($query, $condition) {
+  }
+
+  /**
+   * @see ChadoField::queryOrder()
+   **/
+  public function queryOrder($query, $order) {
+  }
+
+  /**
+   * @see ChadoField::elementInfo()
+   **/
+  public function elementInfo() {
+    $field_term = $this->getFieldTermID();
+    return [
+      $field_term => [
+        'operations' => ['eq', 'ne', 'contains', 'starts'],
+        'sortable' => TRUE,
+        'searchable' => TRUE,
+      ],
+    ];
+  }
+}

--- a/includes/TripalFields/local__child_annotations/local__child_annotations_formatter.inc
+++ b/includes/TripalFields/local__child_annotations/local__child_annotations_formatter.inc
@@ -7,21 +7,10 @@
  * Display:
  * Configuration:
  */
-class local__child_properties_formatter extends ChadoFieldFormatter {
+class local__child_annotations_formatter extends ChadoFieldFormatter {
 
-  /**
-   * The default label for this field.
-   */
-  public static $default_label = 'Child Properties';
-
-  /**
-   * The list of field types for which this formatter is appropriate.
-   */
-  public static $field_types = ['local__child_properties'];
-
-  /**
-   * The list of default settings for this formatter.
-   */
+  public static $default_label = 'Child Annotations';
+  public static $field_types = ['local__child_annotations'];
   public static $default_settings = [
     'setting1' => 'default_value',
   ];
@@ -42,21 +31,21 @@ class local__child_properties_formatter extends ChadoFieldFormatter {
     $settings = $display['settings'];
 
     // For now, values come from the data__sequence_features field.
-     $data = $entity->{'data__sequence_features'}['und'];
-   // $data = $entity->{'local__child_properties'}['und'];
+    $data = $entity->{'data__sequence_features'}['und'];
 
     if (!$data) {
+
       return;
     }
-
-    $i = 0;
 
     foreach ($data as $i => $value) {
 
       $child = $value['value'];
-
-      // TODO: this is an extra undefined!  bad.
       // Assumption: we're on the gene entity.  We've got an array of mRNA feature ID's.
+
+      if (!$child) {
+        continue;
+      }
       $header = [
         'Feature Name',
         'Feature Type',
@@ -66,7 +55,6 @@ class local__child_properties_formatter extends ChadoFieldFormatter {
 
       $info = $child['info'];
       $name = $info->uniquename;
-
       $element[0][$i] = [
         '#type' => 'fieldset',
         '#title' => $name,
@@ -76,35 +64,29 @@ class local__child_properties_formatter extends ChadoFieldFormatter {
             'collapsed',
           ],
         ],
-        // see: https://www.drupal.org/forum/support/module-development-and-code-questions/2012-02-07/drupal-render-fieldset-element
         '#attached' => ['js' => ['misc/collapse.js', 'misc/form.js']],
       ];
 
-      $rows = $this->getPropRows($child);
+      $rows = $this->getAnnotationRows($child);
 
       $table = theme('table', ['rows' => $rows, 'header' => $header]);
       $element[0][$i]['prop_table'] = [
         '#markup' => $table,
-        '#title' => t("Child Properties for !root", ['!root' => $name]),
+        '#title' => t("Child Annotations for !root", ['!root' => $name]),
       ];
-
-      $rows = $this->getAnnotationRows($child);
-      $header = ['name', 'type', 'annotation'];
-
-      $table = theme('table', ['rows' => $rows, 'header' => $header]);
-      $element[0][$i]['annotation_table'] = [
-        '#markup' => $table,
-        '#title' => t("Annotations for !root", ['!root' => $name]),
-      ];
-
-      $i++;
     }
   }
 
   /**
-   * This functionality should move to a separate field.
+   * Recursively goes through the child feature array for annotation listings.
+   *   Such listings are in feature_cvterm.
    *
-   * @param $data
+   * @param array $data
+   *   Data formatted by the data__sequence_features field.
+   *    Expects an info and a children key.
+   *
+   * @return array
+   *   Rows array suitable for table.
    */
   private function getAnnotationRows($data) {
 
@@ -157,57 +139,6 @@ class local__child_properties_formatter extends ChadoFieldFormatter {
     }
     return $rows;
 
-  }
-
-  /**
-   * Recursively goes through the child feature array and builds an array of.
-   *
-   * @param $data
-   */
-  private function getPropRows($data) {
-
-    $rows = [];
-
-    $info = $data['info'];
-
-    $children = $data['children'] ?? NULL;
-
-    $props = $info->featureprop;
-
-    if ($props) {
-
-      // If there is only one property, it will be an object not an array.
-      if (is_array($props)) {
-        foreach ($props as $prop) {
-          $rows[] = [
-            $info->uniquename,
-            $info->type_id->name,
-            $prop->type_id->name,
-            $prop->value,
-          ];
-        }
-      }
-      else {
-        $rows[] = [
-          $info->uniquename,
-          $info->type_id->name,
-          $props->type_id->name,
-          $props->value,
-        ];
-
-      }
-
-    }
-
-    if ($children && !empty($children)) {
-
-      foreach ($children as $child) {
-        $result = array_merge($this->getPropRows($child), $rows);
-
-        $rows = $result;
-      }
-    }
-    return $rows;
   }
 
   /**

--- a/includes/TripalFields/local__child_annotations/local__child_annotations_formatter.inc
+++ b/includes/TripalFields/local__child_annotations/local__child_annotations_formatter.inc
@@ -31,10 +31,9 @@ class local__child_annotations_formatter extends ChadoFieldFormatter {
     $settings = $display['settings'];
 
     // For now, values come from the data__sequence_features field.
-    $data = $entity->{'data__sequence_features'}['und'];
+    $data = $entity->data__sequence_features['und'];
 
     if (!$data) {
-
       return;
     }
 
@@ -49,8 +48,7 @@ class local__child_annotations_formatter extends ChadoFieldFormatter {
       $header = [
         'Feature Name',
         'Feature Type',
-        'Property Name',
-        'Property Value',
+        'Annotation Name',
       ];
 
       $info = $child['info'];
@@ -69,8 +67,15 @@ class local__child_annotations_formatter extends ChadoFieldFormatter {
 
       $rows = $this->getAnnotationRows($child);
 
+      if (empty($rows)) {
+        $element[0][$i]['annotation_table'] = [
+          '#markup' => 'No annotations associated with ' . $info->uniquename
+        ];
+        continue;
+
+      }
       $table = theme('table', ['rows' => $rows, 'header' => $header]);
-      $element[0][$i]['prop_table'] = [
+      $element[0][$i]['annotation_table'] = [
         '#markup' => $table,
         '#title' => t("Child Annotations for !root", ['!root' => $name]),
       ];
@@ -97,6 +102,7 @@ class local__child_annotations_formatter extends ChadoFieldFormatter {
     $children = $data['children'] ?? NULL;
 
     $annotations = $info->feature_cvterm;
+    $yo = chado_query('select * from {feature_cvterm} where feature_id = :id;', [':id' => $info->feature_id])->fetchObject();
 
     if ($annotations) {
 

--- a/includes/TripalFields/local__child_annotations/local__child_annotations_formatter.inc
+++ b/includes/TripalFields/local__child_annotations/local__child_annotations_formatter.inc
@@ -102,7 +102,6 @@ class local__child_annotations_formatter extends ChadoFieldFormatter {
     $children = $data['children'] ?? NULL;
 
     $annotations = $info->feature_cvterm;
-    $yo = chado_query('select * from {feature_cvterm} where feature_id = :id;', [':id' => $info->feature_id])->fetchObject();
 
     if ($annotations) {
 

--- a/includes/TripalFields/local__child_annotations/local__child_annotations_widget.inc
+++ b/includes/TripalFields/local__child_annotations/local__child_annotations_widget.inc
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ *
+ * Data:
+ * Assumptions:
+ */
+class local__child_annotations_widget extends ChadoFieldWidget {
+
+  // The default label for this field.
+  public static $default_label = 'Child Properties';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('local__child_annotations');
+
+
+ /**
+  * @see ChadoFieldWidget::form()
+  *
+  **/
+
+  public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+  }
+
+  /**
+  * @see ChadoFieldWidget::validate()
+  *
+  **/
+  public function validate($element, $form, &$form_state, $langcode, $delta) {
+  }
+
+   /**
+  * @see ChadoFieldWidget::submit()
+  *
+  **/
+  public function submit($form, &$form_state, $entity_type, $entity, $langcode, $delta) {
+  }
+
+}

--- a/includes/TripalFields/local__child_properties/local__child_properties.inc
+++ b/includes/TripalFields/local__child_properties/local__child_properties.inc
@@ -131,12 +131,9 @@ class local__child_properties extends ChadoField {
     // additional data to be used in the display, you should add it here.
     parent::load($entity);
 
-    $master = $entity->data__sequence_features['und'];
-
-    //TODO: filter this to just hte properties.  Right now we include everything because we are having this field do double duty for annotations.
-      $entity->local__child_properties['und'] = $master;
-
-
+    //  We should load in the data here.
+    //  As a stopgap, we simply use the data loaded by the parent field in the formatter instead.
+    $entity->local__child_properties['und'][0]['value'] = TRUE;
 
   }
 

--- a/includes/TripalFields/local__child_properties/local__child_properties_formatter.inc
+++ b/includes/TripalFields/local__child_properties/local__child_properties_formatter.inc
@@ -42,14 +42,11 @@ class local__child_properties_formatter extends ChadoFieldFormatter {
     $settings = $display['settings'];
 
     // For now, values come from the data__sequence_features field.
-     $data = $entity->{'data__sequence_features'}['und'];
-   // $data = $entity->{'local__child_properties'}['und'];
+     $data = $entity->data__sequence_features['und'];
 
     if (!$data) {
       return;
     }
-
-    $i = 0;
 
     foreach ($data as $i => $value) {
 
@@ -82,81 +79,20 @@ class local__child_properties_formatter extends ChadoFieldFormatter {
 
       $rows = $this->getPropRows($child);
 
+
+      if (empty($rows)) {
+        $element[0][$i]['prop_table'] = [
+          '#markup' => 'No properties associated with ' . $info->uniquename
+        ];
+        continue;
+      }
+
       $table = theme('table', ['rows' => $rows, 'header' => $header]);
       $element[0][$i]['prop_table'] = [
         '#markup' => $table,
         '#title' => t("Child Properties for !root", ['!root' => $name]),
       ];
-
-      $rows = $this->getAnnotationRows($child);
-      $header = ['name', 'type', 'annotation'];
-
-      $table = theme('table', ['rows' => $rows, 'header' => $header]);
-      $element[0][$i]['annotation_table'] = [
-        '#markup' => $table,
-        '#title' => t("Annotations for !root", ['!root' => $name]),
-      ];
-
-      $i++;
     }
-  }
-
-  /**
-   * This functionality should move to a separate field.
-   *
-   * @param $data
-   */
-  private function getAnnotationRows($data) {
-
-    $rows = [];
-
-    $info = $data['info'];
-
-    $children = $data['children'] ?? NULL;
-
-    $annotations = $info->feature_cvterm;
-
-    if ($annotations) {
-
-      if (is_array($annotations)) {
-        foreach ($annotations as $ann) {
-
-          $annotation_name = $ann->cvterm_id->name;
-          if ($ann->is_not) {
-            $annotation_name = "is not " . $annotation_name;
-          }
-
-          $rows[] = [
-            $info->uniquename,
-            $info->type_id->name,
-            $annotation_name,
-          ];
-        }
-      }
-      else {
-        $annotation_name = $annotations->cvterm_id->name;
-        if ($annotations->is_not) {
-          $annotation_name = "is not " . $annotation_name;
-        }
-
-        $rows[] = [
-          $info->uniquename,
-          $info->type_id->name,
-          $annotation_name,
-        ];
-
-      }
-
-    }
-
-    if ($children && !empty($children)) {
-
-      foreach ($children as $child) {
-        $rows = array_merge($this->getAnnotationRows($child), $rows);
-      }
-    }
-    return $rows;
-
   }
 
   /**

--- a/includes/tripal_manage_analyses.fields.inc
+++ b/includes/tripal_manage_analyses.fields.inc
@@ -80,7 +80,7 @@ function tripal_manage_analyses_bundle_fields_info($entity_type, $bundle) {
 
     $field_name = 'local__child_annotations';
     $field_type = 'local__child_annotations';
-    $info[$field_name] = [
+    $fields[$field_name] = [
       'field_name' => $field_name,
       'type' => $field_type,
       'cardinality' => 1,
@@ -302,7 +302,7 @@ function tripal_manage_analyses_bundle_instances_info($entity_type, $bundle) {
 
 
     $field_name = 'local__child_annotations';
-    $info[$field_name] = [
+    $instances[$field_name] = [
       'field_name' => $field_name,
       'entity_type' => $entity_type,
       'bundle' => $bundle->name,

--- a/includes/tripal_manage_analyses.fields.inc
+++ b/includes/tripal_manage_analyses.fields.inc
@@ -147,7 +147,7 @@ function tripal_manage_analyses_bundle_fields_info($entity_type, $bundle) {
     ];
 
     tripal_insert_cvterm([
-      'id' => 'ero:0000160',
+      'id' => 'ERO:0000160',
       'name' => 'nucleic_acid_library',
       'cv_name' => 'ero',
       'definition' => 'Reagent library that is a collection of DNA fragments that is stored and propagated in a population of micro-organisms through the process of molecular cloning.',

--- a/includes/tripal_manage_analyses.fields.inc
+++ b/includes/tripal_manage_analyses.fields.inc
@@ -71,6 +71,24 @@ function tripal_manage_analyses_bundle_fields_info($entity_type, $bundle) {
         'type' => 'field_chado_storage',
       ],
     ];
+    tripal_insert_cvterm([
+      'id' => 'local:child_annotations',
+      'name' => 'child_annotations',
+      'cv_name' => 'local',
+      'definition' => 'Annotations associated with children of a feature.',
+    ]);
+
+    $field_name = 'local__child_annotations';
+    $field_type = 'local__child_annotations';
+    $info[$field_name] = [
+      'field_name' => $field_name,
+      'type' => $field_type,
+      'cardinality' => 1,
+      'locked' => FALSE,
+      'storage' => [
+        'type' => 'field_chado_storage',
+      ],
+    ];
 
   }
 
@@ -277,6 +295,39 @@ function tripal_manage_analyses_bundle_instances_info($entity_type, $bundle) {
           'label' => 'hidden',
           'type' => 'local__child_properties_formatter',
           //Set the weight high so that it loads after the master field
+          'settings' => ['weight' => 500],
+        ],
+      ],
+    ];
+
+
+    $field_name = 'local__child_annotations';
+    $info[$field_name] = [
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle->name,
+      'label' => 'Child Annotations',
+      'description' => 'Displays annotation information associated with recursive children of this feature.',
+      'required' => FALSE,
+      'settings' => [
+        'term_vocabulary' => 'local',
+        'term_name' => 'child_annotations',
+        'term_accession' => 'child_annotations',
+        'auto_attach' => FALSE,
+        'chado_table' => 'feature_cvterm',
+        'chado_column' => 'feature_id',
+        'base_table' => $bundle->data_table,
+      ],
+      'widget' => [
+        'type' => 'local__child_annotations_widget',
+        'settings' => [],
+      ],
+      'display' => [
+        'default' => [
+          'label' => 'hidden',
+          'type' => 'local__child_annotations_formatter',
+          // This field depends on the data__sequence_features field.
+          // The weight must be set to ensure it loads after this field.
           'settings' => ['weight' => 500],
         ],
       ],

--- a/tripal_manage_analyses.install
+++ b/tripal_manage_analyses.install
@@ -98,3 +98,27 @@ function create_organism_analysis_table() {
 function tripal_manage_analyses_update_7305() {
   create_organism_analysis_table();
 }
+
+
+/**
+ * Replace typo with the nucleic_acid_library term db association.
+ * If a warning about "Could not find details about the vocabulary: ero" persists
+ * delete the library field and "check for new fields".
+ */
+function tripal_manage_analyses_update_7306() {
+
+  $term = chado_get_cvterm(['id' => 'ero:0000160']);
+
+  if ($term) {
+    $id = $term->cvterm_id;
+    chado_delete_record('cvterm', ['cvterm_id' => $id]);
+  }
+
+  tripal_insert_cvterm([
+    'id' => 'ERO:0000160',
+    'name' => 'nucleic_acid_library',
+    'cv_name' => 'ero',
+    'definition' => 'Reagent library that is a collection of DNA fragments that is stored and propagated in a population of micro-organisms through the process of molecular cloning.',
+  ]);
+
+}


### PR DESCRIPTION
Adds in "slim" fields that use the parent's `load`.  a dummy version of https://github.com/tripal/tripal/pull/837 so sites can have gene fields *now*.