### PR TITLE
make collapsibility compatible with base and bootstrap

### DIFF
--- a/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
@@ -106,15 +106,17 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
       $element[$i] = [
         '#type' => 'fieldset',
         '#title' => $name,
+        '#collapsed' => TRUE,
+        '#collapsible' => TRUE,
         '#attributes' => [
           'class' => [
             'collapsible',
             'collapsed',
           ],
         ],
-        // see: https://www.drupal.org/forum/support/module-development-and-code-questions/2012-02-07/drupal-render-fieldset-element
-        '#attached' => ['js' => ['misc/collapse.js', 'misc/form.js']],
+        '#attached' => ['js' => ['misc/collapse.js', 'misc.form.js']],
       ];
+
       $element[$i]['drawing'] = [
         '#type' => 'item',
         '#title' => t('Drawing'),

--- a/includes/TripalFields/local__child_annotations/local__child_annotations_formatter.inc
+++ b/includes/TripalFields/local__child_annotations/local__child_annotations_formatter.inc
@@ -56,15 +56,16 @@ class local__child_annotations_formatter extends ChadoFieldFormatter {
       $element[0][$i] = [
         '#type' => 'fieldset',
         '#title' => $name,
-        '#attributes' => [
-          'class' => [
-            'collapsible',
-            'collapsed',
-          ],
-        ],
-        '#attached' => ['js' => ['misc/collapse.js', 'misc/form.js']],
+        '#collapsed' => TRUE,
+        '#collapsible' => TRUE,
+                '#attributes' => [
+                  'class' => [
+                    'collapsible',
+                    'collapsed',
+                  ],
+                ],
+                '#attached' => ['js' => ['misc/collapse.js', 'misc.form.js']],
       ];
-
       $rows = $this->getAnnotationRows($child);
 
       if (empty($rows)) {

--- a/includes/TripalFields/local__child_properties/local__child_properties_formatter.inc
+++ b/includes/TripalFields/local__child_properties/local__child_properties_formatter.inc
@@ -67,14 +67,15 @@ class local__child_properties_formatter extends ChadoFieldFormatter {
       $element[0][$i] = [
         '#type' => 'fieldset',
         '#title' => $name,
+        '#collapsed' => TRUE,
+        '#collapsible' => TRUE,
         '#attributes' => [
           'class' => [
             'collapsible',
             'collapsed',
           ],
         ],
-        // see: https://www.drupal.org/forum/support/module-development-and-code-questions/2012-02-07/drupal-render-fieldset-element
-        '#attached' => ['js' => ['misc/collapse.js', 'misc/form.js']],
+        '#attached' => ['js' => ['misc/collapse.js', 'misc.form.js']],
       ];
 
       $rows = $this->getPropRows($child);


### PR DESCRIPTION
collapsible elements in renderable arrays need:

```
  '#collapsed' => TRUE,
        '#collapsible' => TRUE,
        '#attributes' => [
          'class' => [
            'collapsible',
            'collapsed',
          ],
        ],
        '#attached' => ['js' => ['misc/collapse.js', 'misc/form.js']],
```

There was confusion about this because in bootstrap, you only need `#collapsible` but in say bartik you need to also add the `class` and `#attached` stuff. 