### PR TITLE
Additional glyph

### DIFF
--- a/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
@@ -46,12 +46,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
   private $masterGlyphData;
 
-  /**
-   * Array of the mRNA info (first level child).
-   * @var
-   */
-  private $mrnaLookup;
-
 
   /**
    * @see ChadoFieldFormatter::settingsForm()
@@ -88,20 +82,24 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
     $sequence = $sequences[0]['residues'] ?? NULL;
 
-      if (!$sequence) {
-        // Fudge a sequence based on the length.
-       $length =  db_select('chado.feature', 'f')->fields('f', ['length'])->condition('feature_id', $srcfeature_id)->execute()->fetchField();
-        if (!$length) {
-          // Fudge the length.
-          $length = '500000';
-        }
-        $sequence = '';
-        $i = 0;
-        while ($i < $length) {
-          $sequence .= 'N';
-          $i++;
-        }
+    if (!$sequence) {
+      // Fudge a sequence based on the length.
+      $length = db_select('chado.feature', 'f')
+        ->fields('f', ['length'])
+        ->condition('feature_id', $srcfeature_id)
+        ->execute()
+        ->fetchField();
+      if (!$length) {
+        // Fudge the length.
+        $length = '500000';
       }
+      $sequence = '';
+      $i = 0;
+      while ($i < $length) {
+        $sequence .= 'N';
+        $i++;
+      }
+    }
 
     $coordinates = $entity->data__sequence_coordinates['und'][0]['value'];
 
@@ -111,11 +109,17 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
     $child_draw['residues'] = $sequence;
 
-    $element[0]['gene_drawing'] = [
-      '#type' => 'item',
-      '#title' => t('mRNAs'),
-      '#prefix' => '<div id="tripal_manage_expression_featureloc_gene">',
-      '#suffix' => '</div>',
+    $child_draw['parameters'] = [
+      'offset' => [
+        'start' => $coordinates['local:fmin'],
+        'end' => $coordinates['local:fmax'],
+      ],
+      'showAxis' => FALSE,
+      'showSequence' => TRUE,
+      'brushActive' => TRUE,
+      'toolbar' => TRUE,
+      'bubbleHelp' => TRUE,
+      'zoomMax' => 3,
     ];
 
 
@@ -125,7 +129,14 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
       $info = $child['info'];
       $name = $info->uniquename;
 
-      $element[$i] = [
+      $element[0]['gene_drawing'] = [
+        '#type' => 'item',
+        '#prefix' => '<div id="tripal_manage_expression_featureloc_gene">',
+        '#suffix' => '</div>',
+      ];
+
+
+      $element[$i]['fs'] = [
         '#type' => 'fieldset',
         '#title' => $name,
         '#collapsed' => TRUE,
@@ -143,7 +154,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
         ],
       ];
 
-      $element[$i]['drawing'] = [
+      $element[$i]['fs']['drawing'] = [
         '#type' => 'item',
         '#title' => t('Drawing'),
         '#prefix' => '<div id="tripal_manage_expression_featureloc_viewer_' . $i . '">',
@@ -154,20 +165,21 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
       //  We assume the primary child feature is mRNA.
       $mrna = $child['info'];
 
-      $this->mrnaLookup[$i] = $mrna;
 
       //Create base mRNA drawing.
       $this->featureviewerData[$i]['mRNA'] = [
-        'name' => $mrna->uniquename,
+        'name' => 'mRNA',
         'color' => '#FF0000',
         'type' => 'rect',
       ];
+
+      $color = '#' . substr(str_shuffle('ABCDEF0123456789'), 0, 6);
 
       //Add this mRNA to mqster drawing.
       $this->masterGlyphData[$i] = [
         'name' => $mrna->uniquename,
         //Color is going to be different for each mRNA!
-        'color' => '#FF0000',
+        'color' => $color,
         'type' => 'rect',
       ];
 
@@ -197,14 +209,14 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
         'Location',
       ];
       $output = theme('table', ['header' => $header, 'rows' => $rows]);
-      $element[$i][$i . 'table'] = ['#markup' => $output];
+      $element[$i]['fs'][$i . 'table'] = ['#markup' => $output];
 
       unset($rows);
 
     }
 
     // Un-collapse the first fieldset.
-    $element[0]['#attributes']['class'] = ['collapsible'];
+    $element[0]['fs']['#attributes']['class'] = ['collapsible'];
 
     $child_draw['children'] = $this->featureviewerData;
     $child_draw['master'] = $this->masterGlyphData;
@@ -280,6 +292,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
   /**
    * Builds table of sub-feature info, extract CDS/exon info for glyphs.
+   *
    * @param $child
    * Full child info.
    * @param $i
@@ -316,7 +329,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
           $locs = db_select('chado.featureloc', 'fl')
             ->condition('fl.feature_id', $info->feature_id)
             ->fields('fl', ['fmin', 'fmax', 'rank'])
-             ->orderBy('rank', 'ASC')
+            ->orderBy('rank', 'ASC')
             ->execute();
 
           if (empty($locs)) {
@@ -324,24 +337,22 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
           }
 
           $this->featureviewerData[$i]['CDS'] = [
-            'name' => $info->uniquename,
-            'color' => '#FF0000',
+            'name' => 'CDS',
+            'color' => '#008000',
             'type' => 'rect',
           ];
 
-          //TODO:  will this break?
           foreach ($locs as $loc) {
             $this->featureviewerData[$i]['CDS']['data'][] = [
               'x' => $loc->fmin,
               'y' => $loc->fmax,
-              'description' => $loc->fmin . '-' . $loc->fmax,
+              'description' => '$info->uniquename',
             ];
           }
           break;
 
 
         case 'exon':
-          $mrna = $this->mrnaLookup[$i];
 
           //exon locations go into the glyph for the mRNA.
 
@@ -358,7 +369,39 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
           $this->featureviewerData[$i]['mRNA']['data'][] = $feature_viewer_array;
 
           break;
+
+        case 'polypeptide':
+        case 'five_prime_UTR':
+        case 'three_prime_UTR':
+          //Dont draw
+          break;
+
+        default:
+          //draw in specific glyph
+
+
+          //generate a random color
+          $color = '#' . substr(str_shuffle('ABCDEF0123456789'), 0, 6);
+
+          $this->featureviewerData[$i][$info->type_id->name] = [
+            'name' => $info->type_id->name,
+            'color' => $color,
+            'type' => 'rect',
+          ];
+
+          $featureloc = $info->featureloc->feature_id;
+          $min = $featureloc->fmin ?? NULL;
+          $max = $featureloc ?? NULL;
+
+          $this->featureviewerData[$i][$info->type_id->name]['data'][] = [
+            'x' => $min,
+            'y' => $max,
+            'description' => $info->uniquename,
+          ];
+          break;
+
       }
+
 
     }
 
@@ -434,7 +477,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
           $seq_string = '';
           foreach ($returned as $sequence) {
             if ($seq_string) {
-              $sequence['residues']= '<br>' . $sequence['residues'];
+              $sequence['residues'] = '<br>' . $sequence['residues'];
             }
             $seq_string .= $sequence['residues'];
           }
@@ -465,5 +508,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     return $out;
 
   }
+
 
 }

--- a/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
@@ -84,7 +84,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     if (!$sequence) {
       // Fudge a sequence based on the length.
       $length = db_select('chado.feature', 'f')
-        ->fields('f', ['length'])
+        ->fields('f', ['seqlen'])
         ->condition('feature_id', $srcfeature_id)
         ->execute()
         ->fetchField();

--- a/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
@@ -26,7 +26,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     'setting1' => 'default_value',
   ];
 
-
   /**
    * Featureloc start rel to parent.
    */
@@ -47,6 +46,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
    */
   private $feature_coords;
 
+  private $featureviewerData;
 
 
   /**
@@ -79,17 +79,26 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
     if (!$sequence) {
 
-      // TODO: we build the derived sequence below.
-      // Let's do it here and store it in a private variable for reuse instead.
-      $length = $entity->data__sequence_length['und'][0]['value'];
-      if (!$length) {
-        $length = '5000';
-      }
-      $sequence = '';
-      $i = 0;
-      while ($i < $length) {
-        $sequence .= 'N';
-        $i++;
+      $feature_id = $entity->chado_record->feature_id;
+
+      $options = ['build_from_parent' => 1];
+      $returned = chado_get_feature_sequences(['feature_id' => $feature_id], $options);
+
+      $sequence = $returned[0]['residues'] ?? NULL;
+
+      if (!$sequence) {
+        // Fudge a sequence based on the length.
+        $length = $entity->data__sequence_length['und'][0]['value'];
+        if (!$length) {
+          // Fudge the length.
+          $length = '5000';
+        }
+        $sequence = '';
+        $i = 0;
+        while ($i < $length) {
+          $sequence .= 'N';
+          $i++;
+        }
       }
 
     }
@@ -101,6 +110,14 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     $this->parent_strand = $coordinates['data:0853'];
 
     $child_draw['residues'] = $sequence;
+
+    $element[0]['gene_drawing'] = [
+      '#type' => 'item',
+      '#title' => t('mRNAs'),
+      '#prefix' => '<div id="tripal_manage_expression_featureloc_gene">',
+      '#suffix' => '</div>',
+    ];
+
 
     foreach ($entity->{'data__sequence_features'}['und'] as $i => $data) {
       $child = $data['value'];
@@ -135,6 +152,14 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
       $rows = $this->buildChildTable($child);
 
+      //Now build glyph data
+
+      //First, get all exons for use with mRNA
+
+      //Now, add mRNA to master glyph with exons
+
+      //Finally build the glyph for this mRNA with just the CDS and mRNA from exons.
+
       $this->build_featureviewer_data($i, $child);
 
       if (empty($rows)) {
@@ -165,8 +190,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
     drupal_add_js(drupal_get_path('module', 'tripal_manage_analyses') . "/theme/js/tripal_manage_analyses_featureloc.js");
 
-    //Add JS that makes the sequence hideable
-
+    // Add JS that makes the sequence hideable.
     drupal_add_js(drupal_get_path('module', 'tripal_manage_analyses') . "/theme/js/hide_show_sequence.js");
 
   }
@@ -180,10 +204,14 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
     $grand_children = $child['children'] ?? NULL;
 
+
+    $exons = $this->prepare_exons_for_mRNA_glyph($i, $info->feature_id, $info);
     // Set base info
     // All child features will be drawn on this one in 'data'
     // Convert and store the coordinates for hte feature viewer.
-    $this->convertFeatureCoords($i, $info->feature_id, $info);
+    $this->convertFeatureCoords($i, $info->feature_id, $info, $exons);
+
+    $this->buildNewDataScheme($i, $info->feature_id, $info);
 
     // Repeat for grandchildren;.
     if ($grand_children) {
@@ -219,14 +247,25 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     return $out;
   }
 
+
   /**
    * Converts featureloc coordinates to be based on the entity.
    *
    * @param $i
    * @param $feature_id
    * @param $info
+   * @param $exons
+   * Array of exon data for drawing the mRNA.
    */
-  private function convertFeatureCoords($i, $feature_id, $info) {
+  private function convertFeatureCoords($i, $feature_id, $info, $exons) {
+
+    $type = $info->type_id->name;
+
+    $use = ['CDS', 'mRNA'];
+
+    if (!in_array($type, $use)){
+
+    }
 
     $featureloc = $info->featureloc->feature_id;
     // TODO: what if theres no featureloc relative to a parent?
@@ -253,22 +292,63 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
     $type = $info->type_id->name;
 
-    $color = $this->get_feature_color($type);
 
-    if (!isset($this->feature_coords[$i][$type])) {
-
-      $this->feature_coords[$i][$type] = [
-        'name' => $type,
-        'color' => $color,
-        'type' => 'rect',
-      ];
+    if ($type == 'mRNA') {
+      //Dont draw the mRNA itself, build it from exons instead.
+      return;
     }
 
-    $this->feature_coords[$i][$type]['data'][] = [
-      'x' => $start,
-      'y' => $stop,
-      'description' => $info->uniquename,
-    ];
+    $cases = ['exon', 'CDS'];
+    if (!inarray($type, $cases)){
+      return;
+    }
+
+    if ($type == 'exon') {
+
+      $name = 'mRNA';
+      //This is going in to build the mRNA
+    }
+
+    if ($type == 'CDS') {
+
+      $name = 'CDS';
+
+      // Build its locations from featureloc instead.
+
+      $query = db_select('chado.featureloc', 'fl');
+        $query->fields('fl', ['fmin', 'fmax']);
+        $query->orderBy('fmin', 'ASC');
+        $query->join('chado.feature', 'f', 'f.feature_id = fl.feature_id');
+        $query->fields('f', ['uniquename']);
+        $query->condition('f.feature_id')->execute();
+
+        $locs = $query->execute();
+        $color = $this->get_feature_color('CDS');
+
+      if (!isset($this->feature_coords[$i]['CDS'])) {
+
+        $this->feature_coords[$i][$type] = [
+          'name' => $info->uniquename,
+          'color' => $color,
+          'type' => 'rect',
+        ];
+      }
+
+        foreach ($locs as $loc) {
+
+          $this->feature_coords[$i]['CDS']['data'][] = [
+            'x' => $loc->fmin,
+            'y' => $loc->fmax,
+            'description' => $loc->fmin . '-' . $loc->fmax,
+          ];
+        }
+    }
+//
+//    $this->feature_coords[$i][$type]['data'][] = [
+//      'x' => $start,
+//      'y' => $stop,
+//      'description' => $info->uniquename,
+//    ];
 
   }
 
@@ -305,7 +385,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
   /**
    *
    */
-  private function buildChildTable($child) {
+  private function buildChildTable($child, $i) {
 
     $rows = [];
 
@@ -338,6 +418,34 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
         'Locations' => $location,
       ];
 
+      if ($info->type_id->name == 'CDS') {
+
+        $this->featureviewerData[$i]['CDS'] = [
+          'name' => $info->uniquename,
+          'color' => $color,
+          'type' => 'rect'
+        ];
+
+        $locs = $this->unwrittenFetchCDSLocArray;
+
+        foreach ($locs as $loc) {
+        $this->feature_coords[$i]['CDS']['data'][] = [
+          'x' => $loc->fmin,
+          'y' => $loc->fmax,
+          'description' => $loc->fmin . '-' . $loc->fmax,
+        ];
+
+      }
+
+
+      }
+
+
+
+
+      }
+
+
       if (isset($gchild['children'])) {
         $ggchild = $this->buildChildTable($gchild);
 
@@ -368,14 +476,12 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
     module_load_include('inc', 'popup', 'includes/popup.api');
 
-
     $type = $info->type_id->name;
     $out = '';
-    // Only display polypeptide, mRNA.
+    // Only display polypeptide, mRNA CDS.
     $check = ['polypeptide', 'mRNA', 'CDS'];
 
-    //might want to offer noncoding RNA?
-
+    // Might want to offer noncoding RNA?
     if (!in_array($type, $check)) {
       $out = 'N/A';
       return $out;
@@ -386,25 +492,38 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     // aggregate: Set to '1' if the sequence should only contain sub features, excluding intro sub feature sequence. For example, set this option to obtain just the coding sequence of an mRNA.
     // sub_feature_types: Only include sub features (or child features) of the types provided in the array.
     // TODO: I guess this should be done in the LOAD instead of the formatter?
-
-
     $returned = chado_get_feature_sequences(['feature_id' => $info->feature_id], $options);
 
+    if (!$returned[0]['residues']) {
 
-    if (!$returned[0]['residues'] && $type === 'mRNA') {
-      $options['derive_from_parent'] = 1;
-      $returned = chado_get_feature_sequences(['feature_id' => $info->feature_id], $options);
-    }
+      switch ($type) {
 
-    foreach ($returned as $sequence) {
+        case 'mRNA':
+          //Build from child exons
+          $options['aggregate'] = 1;
+          $options['sub_feature_types'] = ['exon'];
+          $returned = chado_get_feature_sequences(['feature_id' => $info->feature_id], $options);
+          break;
 
-      $seq_string = $sequence['residues'];
-      $header = $sequence['defline'] ?? $info->name;
+        case 'CDS':
+          $options['derive_from_parent'] = 1;
+          $returned = chado_get_feature_sequences(['feature_id' => $info->feature_id], $options);
+          break;
 
-      $defline = '>' . $header . '<br>';
+        default:
+          break;
+      }
 
-      if ($seq_string) {
-        $out .= $defline . $seq_string;
+      foreach ($returned as $sequence) {
+
+        $seq_string = $sequence['residues'];
+        $header = $sequence['defline'] ?? $info->name;
+
+        $defline = '>' . $header . '<br>';
+
+        if ($seq_string) {
+          $out .= $defline . $seq_string;
+        }
       }
     }
 
@@ -415,7 +534,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
       $out = '
       <a id="' . $container_id . '"data-target="' . $id . '" class="sequence-expand-trigger">Sequence</a>
-      <div style="display: none;" class="tripal-sequence-popover" id ="' . $id  . '"> ' . $out .  '</div>';
+      <div style="display: none;" class="tripal-sequence-popover" id ="' . $id . '"> ' . $out . '</div>';
     }
 
     if (!$out) {

--- a/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
@@ -46,7 +46,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
   private $masterGlyphData;
 
-
   /**
    * @see ChadoFieldFormatter::settingsForm()
    **/
@@ -122,7 +121,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
       'zoomMax' => 3,
     ];
 
-
     foreach ($entity->{'data__sequence_features'}['und'] as $i => $data) {
       $child = $data['value'];
 
@@ -134,7 +132,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
         '#prefix' => '<div id="tripal_manage_expression_featureloc_gene">',
         '#suffix' => '</div>',
       ];
-
 
       $element[$i]['fs'] = [
         '#type' => 'fieldset',
@@ -156,17 +153,14 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
       $element[$i]['fs']['drawing'] = [
         '#type' => 'item',
-        '#title' => t('Drawing'),
         '#prefix' => '<div id="tripal_manage_expression_featureloc_viewer_' . $i . '">',
         '#suffix' => '</div>',
       ];
 
-
-      //  We assume the primary child feature is mRNA.
+      // We assume the primary child feature is mRNA.
       $mrna = $child['info'];
 
-
-      //Create base mRNA drawing.
+      // Create base mRNA drawing.
       $this->featureviewerData[$i]['mRNA'] = [
         'name' => 'mRNA',
         'color' => '#FF0000',
@@ -175,10 +169,10 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
       $color = '#' . substr(str_shuffle('ABCDEF0123456789'), 0, 6);
 
-      //Add this mRNA to mqster drawing.
+      // Add this mRNA to mqster drawing.
       $this->masterGlyphData[$i] = [
         'name' => $mrna->uniquename,
-        //Color is going to be different for each mRNA!
+        // Color is going to be different for each mRNA!
         'color' => $color,
         'type' => 'rect',
       ];
@@ -194,8 +188,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
         'Locations' => $location,
       ];
 
-      //Build the table of all child features. use CDS and exon subfeatures for the glyphs.
-
+      // Build the table of all child features. use CDS and exon subfeatures for the glyphs.
       $rows = array_merge($rows, $this->buildChildTable($child, $i));
 
       if (empty($rows)) {
@@ -232,7 +225,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
   }
 
-
   /**
    * Builds featureloc string for display to user.
    *
@@ -258,7 +250,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
     return $out;
   }
-
 
   /**
    * A color lookup to pass different colors to different feature subtypes.
@@ -294,11 +285,11 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
    * Builds table of sub-feature info, extract CDS/exon info for glyphs.
    *
    * @param $child
-   * Full child info.
+   *   Full child info.
    * @param $i
    *
    * @return array
-   * Returns array of rows.
+   *   Returns array of rows.
    */
   private function buildChildTable($child, $i) {
 
@@ -319,12 +310,11 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
         'Locations' => $location,
       ];
 
-
       switch ($info->type_id->name) {
 
         case 'CDS':
 
-          //Get locations.  We assume the single CDS feature has multiple featurelocs, which is anti-Chado but what must be done, see:
+          // Get locations.  We assume the single CDS feature has multiple featurelocs, which is anti-Chado but what must be done, see:
           // @ticket https://github.com/tripal/tripal/issues/52
           $locs = db_select('chado.featureloc', 'fl')
             ->condition('fl.feature_id', $info->feature_id)
@@ -346,16 +336,14 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
             $this->featureviewerData[$i]['CDS']['data'][] = [
               'x' => $loc->fmin,
               'y' => $loc->fmax,
-              'description' => '$info->uniquename',
+              'description' => $info->uniquename,
             ];
           }
           break;
 
-
         case 'exon':
 
-          //exon locations go into the glyph for the mRNA.
-
+          // Exon locations go into the glyph for the mRNA.
           $loc = $info->featureloc->feature_id;
 
           $feature_viewer_array = [
@@ -373,14 +361,12 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
         case 'polypeptide':
         case 'five_prime_UTR':
         case 'three_prime_UTR':
-          //Dont draw
+          // Dont draw.
           break;
 
         default:
-          //draw in specific glyph
-
-
-          //generate a random color
+          // Draw in specific glyph
+          // generate a random color.
           $color = '#' . substr(str_shuffle('ABCDEF0123456789'), 0, 6);
 
           $this->featureviewerData[$i][$info->type_id->name] = [
@@ -402,9 +388,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
       }
 
-
     }
-
 
     if (isset($gchild['children'])) {
       $ggchild = $this->buildChildTable($gchild, $i);
@@ -457,11 +441,10 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
     if (!$returned[0]['residues']) {
 
-
       switch ($type) {
 
         case 'mRNA':
-          //Build from child exons
+          // Build from child exons.
           $options['aggregate'] = 1;
           $options['sub_feature_types'] = ['exon'];
           $returned = chado_get_feature_sequences(['feature_id' => $info->feature_id], $options);
@@ -508,6 +491,5 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     return $out;
 
   }
-
 
 }

--- a/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features_formatter.inc
@@ -41,12 +41,16 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
    */
   private $parent_strand;
 
-  /**
-   * Holds converted featureloc information for the feature viewer drawing.
-   */
-  private $feature_coords;
 
   private $featureviewerData;
+
+  private $masterGlyphData;
+
+  /**
+   * Array of the mRNA info (first level child).
+   * @var
+   */
+  private $mrnaLookup;
 
 
   /**
@@ -64,8 +68,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     // Get the settings.
     $settings = $display['settings'];
 
-    $parent = $entity->chado_record->feature_id;
-
     drupal_add_js("https://cdn.rawgit.com/calipho-sib/feature-viewer/v1.0.4/dist/feature-viewer.bundle.js", [
       'type' => 'external',
       'scope' => 'header',
@@ -75,23 +77,23 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     ]);
 
     $child_draw = [];
-    $sequence = $entity->data__sequence['und'][0]['value'];
 
-    if (!$sequence) {
+    $srcfeature_id = db_select('chado.featureloc', 'fl')
+      ->fields('fl', ['srcfeature_id'])
+      ->condition('feature_id', $entity->chado_record->feature_id)
+      ->execute()
+      ->fetchField();
 
-      $feature_id = $entity->chado_record->feature_id;
+    $sequences = chado_get_feature_sequences(['feature_id' => $srcfeature_id], []);
 
-      $options = ['build_from_parent' => 1];
-      $returned = chado_get_feature_sequences(['feature_id' => $feature_id], $options);
-
-      $sequence = $returned[0]['residues'] ?? NULL;
+    $sequence = $sequences[0]['residues'] ?? NULL;
 
       if (!$sequence) {
         // Fudge a sequence based on the length.
-        $length = $entity->data__sequence_length['und'][0]['value'];
+       $length =  db_select('chado.feature', 'f')->fields('f', ['length'])->condition('feature_id', $srcfeature_id)->execute()->fetchField();
         if (!$length) {
           // Fudge the length.
-          $length = '5000';
+          $length = '500000';
         }
         $sequence = '';
         $i = 0;
@@ -100,8 +102,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
           $i++;
         }
       }
-
-    }
 
     $coordinates = $entity->data__sequence_coordinates['und'][0]['value'];
 
@@ -150,17 +150,41 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
         '#suffix' => '</div>',
       ];
 
-      $rows = $this->buildChildTable($child);
 
-      //Now build glyph data
+      //  We assume the primary child feature is mRNA.
+      $mrna = $child['info'];
 
-      //First, get all exons for use with mRNA
+      $this->mrnaLookup[$i] = $mrna;
 
-      //Now, add mRNA to master glyph with exons
+      //Create base mRNA drawing.
+      $this->featureviewerData[$i]['mRNA'] = [
+        'name' => $mrna->uniquename,
+        'color' => '#FF0000',
+        'type' => 'rect',
+      ];
 
-      //Finally build the glyph for this mRNA with just the CDS and mRNA from exons.
+      //Add this mRNA to mqster drawing.
+      $this->masterGlyphData[$i] = [
+        'name' => $mrna->uniquename,
+        //Color is going to be different for each mRNA!
+        'color' => '#FF0000',
+        'type' => 'rect',
+      ];
 
-      $this->build_featureviewer_data($i, $child);
+      $sequence = $this->buildSequence($mrna);
+      $location = isset($mrna->featureloc) ? $this->buildFeatureString($mrna->featureloc) : 'Not available';
+      $rows = [];
+
+      $rows[] = [
+        'Name' => $mrna->uniquename,
+        'Type' => $mrna->type_id->name,
+        'Sequence' => $sequence,
+        'Locations' => $location,
+      ];
+
+      //Build the table of all child features. use CDS and exon subfeatures for the glyphs.
+
+      $rows = array_merge($rows, $this->buildChildTable($child, $i));
 
       if (empty($rows)) {
         continue;
@@ -182,7 +206,8 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     // Un-collapse the first fieldset.
     $element[0]['#attributes']['class'] = ['collapsible'];
 
-    $child_draw['children'] = $this->feature_coords;
+    $child_draw['children'] = $this->featureviewerData;
+    $child_draw['master'] = $this->masterGlyphData;
     // Pass in the needed JS info.
     drupal_add_js([
       'children_draw_info' => $child_draw,
@@ -195,31 +220,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
   }
 
-  /**
-   *
-   */
-  private function build_featureviewer_data($i, $child) {
-
-    $info = $child['info'];
-
-    $grand_children = $child['children'] ?? NULL;
-
-
-    $exons = $this->prepare_exons_for_mRNA_glyph($i, $info->feature_id, $info);
-    // Set base info
-    // All child features will be drawn on this one in 'data'
-    // Convert and store the coordinates for hte feature viewer.
-    $this->convertFeatureCoords($i, $info->feature_id, $info, $exons);
-
-    $this->buildNewDataScheme($i, $info->feature_id, $info);
-
-    // Repeat for grandchildren;.
-    if ($grand_children) {
-      foreach ($grand_children as $grand_child) {
-        $this->build_featureviewer_data($i, $grand_child);
-      }
-    }
-  }
 
   /**
    * Builds featureloc string for display to user.
@@ -247,110 +247,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     return $out;
   }
 
-
-  /**
-   * Converts featureloc coordinates to be based on the entity.
-   *
-   * @param $i
-   * @param $feature_id
-   * @param $info
-   * @param $exons
-   * Array of exon data for drawing the mRNA.
-   */
-  private function convertFeatureCoords($i, $feature_id, $info, $exons) {
-
-    $type = $info->type_id->name;
-
-    $use = ['CDS', 'mRNA'];
-
-    if (!in_array($type, $use)){
-
-    }
-
-    $featureloc = $info->featureloc->feature_id;
-    // TODO: what if theres no featureloc relative to a parent?
-    $parent_start = $this->parent_start;
-    $parent_stop = $this->parent_stop;
-    $strand = $this->parent_strand;
-
-    $min = $featureloc->fmin ?? NULL;
-    $max = $featureloc->fmax ?? NULL;
-    $strand = $featureloc->strand ?? NULL;
-
-    if ($strand == '+') {
-
-      // It doesnt matter what strand it is, we always do this.
-      // TODO: check that assertion.
-      $start = $min - $parent_start + 1;
-      $stop = $max - $parent_start + 1;
-    }
-
-    else {
-      $start = $min - $parent_start + 1;
-      $stop = $max - $parent_start + 1;
-    }
-
-    $type = $info->type_id->name;
-
-
-    if ($type == 'mRNA') {
-      //Dont draw the mRNA itself, build it from exons instead.
-      return;
-    }
-
-    $cases = ['exon', 'CDS'];
-    if (!inarray($type, $cases)){
-      return;
-    }
-
-    if ($type == 'exon') {
-
-      $name = 'mRNA';
-      //This is going in to build the mRNA
-    }
-
-    if ($type == 'CDS') {
-
-      $name = 'CDS';
-
-      // Build its locations from featureloc instead.
-
-      $query = db_select('chado.featureloc', 'fl');
-        $query->fields('fl', ['fmin', 'fmax']);
-        $query->orderBy('fmin', 'ASC');
-        $query->join('chado.feature', 'f', 'f.feature_id = fl.feature_id');
-        $query->fields('f', ['uniquename']);
-        $query->condition('f.feature_id')->execute();
-
-        $locs = $query->execute();
-        $color = $this->get_feature_color('CDS');
-
-      if (!isset($this->feature_coords[$i]['CDS'])) {
-
-        $this->feature_coords[$i][$type] = [
-          'name' => $info->uniquename,
-          'color' => $color,
-          'type' => 'rect',
-        ];
-      }
-
-        foreach ($locs as $loc) {
-
-          $this->feature_coords[$i]['CDS']['data'][] = [
-            'x' => $loc->fmin,
-            'y' => $loc->fmax,
-            'description' => $loc->fmin . '-' . $loc->fmax,
-          ];
-        }
-    }
-//
-//    $this->feature_coords[$i][$type]['data'][] = [
-//      'x' => $start,
-//      'y' => $stop,
-//      'description' => $info->uniquename,
-//    ];
-
-  }
 
   /**
    * A color lookup to pass different colors to different feature subtypes.
@@ -383,7 +279,13 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
   }
 
   /**
+   * Builds table of sub-feature info, extract CDS/exon info for glyphs.
+   * @param $child
+   * Full child info.
+   * @param $i
    *
+   * @return array
+   * Returns array of rows.
    */
   private function buildChildTable($child, $i) {
 
@@ -391,24 +293,10 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
 
     $children = $child['children'];
 
-    $mrna = $child['info'];
-
-    $sequence = $this->buildSequence($mrna);
-    $location = isset($mrna->featureloc) ? $this->buildFeatureString($mrna->featureloc) : 'Not available';
-
-    $rows[] = [
-      'Name' => $mrna->uniquename,
-      'Type' => $mrna->type_id->name,
-      'Sequence' => $sequence,
-      'Locations' => $location,
-    ];
-
     foreach ($children as $gchild) {
 
       $info = $gchild['info'];
-
       $location = isset($info->featureloc) ? $this->buildFeatureString($info->featureloc) : 'Not available';
-
       $sequence = $this->buildSequence($info);
 
       $rows[] = [
@@ -418,42 +306,70 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
         'Locations' => $location,
       ];
 
-      if ($info->type_id->name == 'CDS') {
 
-        $this->featureviewerData[$i]['CDS'] = [
-          'name' => $info->uniquename,
-          'color' => $color,
-          'type' => 'rect'
-        ];
+      switch ($info->type_id->name) {
 
-        $locs = $this->unwrittenFetchCDSLocArray;
+        case 'CDS':
 
-        foreach ($locs as $loc) {
-        $this->feature_coords[$i]['CDS']['data'][] = [
-          'x' => $loc->fmin,
-          'y' => $loc->fmax,
-          'description' => $loc->fmin . '-' . $loc->fmax,
-        ];
+          //Get locations.  We assume the single CDS feature has multiple featurelocs, which is anti-Chado but what must be done, see:
+          // @ticket https://github.com/tripal/tripal/issues/52
+          $locs = db_select('chado.featureloc', 'fl')
+            ->condition('fl.feature_id', $info->feature_id)
+            ->fields('fl', ['fmin', 'fmax', 'rank'])
+             ->orderBy('rank', 'ASC')
+            ->execute();
 
-      }
+          if (empty($locs)) {
+            break;
+          }
+
+          $this->featureviewerData[$i]['CDS'] = [
+            'name' => $info->uniquename,
+            'color' => '#FF0000',
+            'type' => 'rect',
+          ];
+
+          //TODO:  will this break?
+          foreach ($locs as $loc) {
+            $this->featureviewerData[$i]['CDS']['data'][] = [
+              'x' => $loc->fmin,
+              'y' => $loc->fmax,
+              'description' => $loc->fmin . '-' . $loc->fmax,
+            ];
+          }
+          break;
 
 
-      }
+        case 'exon':
+          $mrna = $this->mrnaLookup[$i];
 
+          //exon locations go into the glyph for the mRNA.
 
+          $loc = $info->featureloc->feature_id;
 
+          $feature_viewer_array = [
+            'x' => $loc->fmin,
+            'y' => $loc->fmax,
+            'description' => $info->uniquename,
+          ];
 
-      }
+          $this->masterGlyphData[$i]['data'][] = $feature_viewer_array;
 
+          $this->featureviewerData[$i]['mRNA']['data'][] = $feature_viewer_array;
 
-      if (isset($gchild['children'])) {
-        $ggchild = $this->buildChildTable($gchild);
-
-        $rows = array_merge($rows, $ggchild);
+          break;
       }
 
     }
+
+
+    if (isset($gchild['children'])) {
+      $ggchild = $this->buildChildTable($gchild, $i);
+
+      $rows = array_merge($rows, $ggchild);
+    }
     return $rows;
+
   }
 
   /**
@@ -464,7 +380,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
   }
 
   /**
-   * Build and display sequence for polypeptides and mRNA.
+   * Build and display sequence for select feature types.
    *
    * @param $info
    *
@@ -480,7 +396,6 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     $out = '';
     // Only display polypeptide, mRNA CDS.
     $check = ['polypeptide', 'mRNA', 'CDS'];
-
     // Might want to offer noncoding RNA?
     if (!in_array($type, $check)) {
       $out = 'N/A';
@@ -494,7 +409,11 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
     // TODO: I guess this should be done in the LOAD instead of the formatter?
     $returned = chado_get_feature_sequences(['feature_id' => $info->feature_id], $options);
 
+    $seq = $returned[0]['residues'] ?? NULL;
+    $header = $returned[0]['defline'] ?? $info->uniquename;
+
     if (!$returned[0]['residues']) {
+
 
       switch ($type) {
 
@@ -503,31 +422,34 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
           $options['aggregate'] = 1;
           $options['sub_feature_types'] = ['exon'];
           $returned = chado_get_feature_sequences(['feature_id' => $info->feature_id], $options);
+          $seq = $returned[0]['residues'] ?? NULL;
           break;
 
         case 'CDS':
           $options['derive_from_parent'] = 1;
+
+          $header = $info->uniquename;
+
           $returned = chado_get_feature_sequences(['feature_id' => $info->feature_id], $options);
+          $seq_string = '';
+          foreach ($returned as $sequence) {
+            if ($seq_string) {
+              $sequence['residues']= '<br>' . $sequence['residues'];
+            }
+            $seq_string .= $sequence['residues'];
+          }
+          $seq = $seq_string;
           break;
 
         default:
           break;
       }
-
-      foreach ($returned as $sequence) {
-
-        $seq_string = $sequence['residues'];
-        $header = $sequence['defline'] ?? $info->name;
-
-        $defline = '>' . $header . '<br>';
-
-        if ($seq_string) {
-          $out .= $defline . $seq_string;
-        }
-      }
     }
+    $defline = '>' . $header . '<br>';
 
-    if ($out) {
+    $out = $defline . $seq;
+
+    if ($out && $seq) {
 
       $container_id = 'popover-controller-' . $info->feature_id;
       $id = 'popover-' . $info->feature_id;
@@ -536,8 +458,7 @@ class data__sequence_features_formatter extends ChadoFieldFormatter {
       <a id="' . $container_id . '"data-target="' . $id . '" class="sequence-expand-trigger">Sequence</a>
       <div style="display: none;" class="tripal-sequence-popover" id ="' . $id . '"> ' . $out . '</div>';
     }
-
-    if (!$out) {
+    else {
       $out = 'Unavailable';
     }
 

--- a/includes/TripalFields/data__sequence_features/data__sequence_features_generic_formatter.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features_generic_formatter.inc
@@ -1,0 +1,323 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ * This is a backup field to use in case the schema in the regular field doesnt work for your site.  This might be the case if dont want your mRNAs composed of exons, for example.
+ *
+ * Display:
+ * Configuration:
+ */
+class data__sequence_features_generic_formatter extends ChadoFieldFormatter {
+  /**
+   * The default label for this field.
+   */
+  public static $default_label = 'Transcript Information';
+  /**
+   * The list of field types for which this formatter is appropriate.
+   */
+  public static $field_types = ['data__sequence_features'];
+  /**
+   * The list of default settings for this formatter.
+   */
+  public static $default_settings = [
+    'setting1' => 'default_value',
+  ];
+  /**
+   * Featureloc start rel to parent.
+   */
+  private $parent_start;
+  /**
+   * Featureloc stop rel to parent.
+   */
+  private $parent_stop;
+  /**
+   * Featureloc strand rel to parent.
+   */
+  private $parent_strand;
+  /**
+   * Holds converted featureloc information for the feature viewer drawing.
+   */
+  private $feature_coords;
+  /**
+   * @see ChadoFieldFormatter::settingsForm()
+   **/
+  public function settingsForm($view_mode, $form, &$form_state) {
+  }
+  /**
+   * @see ChadoFieldFormatter::View()
+   **/
+  public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
+    // Get the settings.
+    $settings = $display['settings'];
+    $parent = $entity->chado_record->feature_id;
+    drupal_add_js("https://cdn.rawgit.com/calipho-sib/feature-viewer/v1.0.4/dist/feature-viewer.bundle.js", [
+      'type' => 'external',
+      'scope' => 'header',
+      'group' => 15,
+      'every_page' => TRUE,
+      'weight' => 500,
+    ]);
+    $child_draw = [];
+    $sequence = $entity->data__sequence['und'][0]['value'];
+    if (!$sequence) {
+      // TODO: we build the derived sequence below.
+      // Let's do it here and store it in a private variable for reuse instead.
+      $length = $entity->data__sequence_length['und'][0]['value'];
+      if (!$length) {
+        $length = '5000';
+      }
+      $sequence = '';
+      $i = 0;
+      while ($i < $length) {
+        $sequence .= 'N';
+        $i++;
+      }
+    }
+    $coordinates = $entity->data__sequence_coordinates['und'][0]['value'];
+    $this->parent_start = $coordinates['local:fmin'];
+    $this->parent_stop = $coordinates['local:fmax'];
+    $this->parent_strand = $coordinates['data:0853'];
+    $child_draw['residues'] = $sequence;
+    foreach ($entity->{'data__sequence_features'}['und'] as $i => $data) {
+      $child = $data['value'];
+      $info = $child['info'];
+      $name = $info->uniquename;
+      $element[$i] = [
+        '#type' => 'fieldset',
+        '#title' => $name,
+        '#collapsed' => TRUE,
+        '#collapsible' => TRUE,
+        '#attributes' => [
+          'class' => [
+            'collapsible',
+            'collapsed',
+          ],
+        ],
+        '#attached' => [
+          'library' => [
+            ['system', 'drupal.collapse'],
+          ],
+        ],
+      ];
+      $element[$i]['drawing'] = [
+        '#type' => 'item',
+        '#title' => t('Drawing'),
+        '#prefix' => '<div id="tripal_manage_expression_featureloc_viewer_' . $i . '">',
+        '#suffix' => '</div>',
+      ];
+      $rows = $this->buildChildTable($child);
+      $this->build_featureviewer_data($i, $child);
+      if (empty($rows)) {
+        continue;
+      }
+      $header = [
+        'Name',
+        'Type',
+        'Sequence',
+        'Location',
+      ];
+      $output = theme('table', ['header' => $header, 'rows' => $rows]);
+      $element[$i][$i . 'table'] = ['#markup' => $output];
+      unset($rows);
+    }
+    // Un-collapse the first fieldset.
+    $element[0]['#attributes']['class'] = ['collapsible'];
+    $child_draw['children'] = $this->feature_coords;
+    // Pass in the needed JS info.
+    drupal_add_js([
+      'children_draw_info' => $child_draw,
+    ], 'setting');
+    drupal_add_js(drupal_get_path('module', 'tripal_manage_analyses') . "/theme/js/tripal_manage_analyses_featureloc.js");
+    //Add JS that makes the sequence hideable
+    drupal_add_js(drupal_get_path('module', 'tripal_manage_analyses') . "/theme/js/hide_show_sequence.js");
+  }
+  /**
+   *
+   */
+  private function build_featureviewer_data($i, $child) {
+    $info = $child['info'];
+    $grand_children = $child['children'] ?? NULL;
+    // Set base info
+    // All child features will be drawn on this one in 'data'
+    // Convert and store the coordinates for hte feature viewer.
+    $this->convertFeatureCoords($i, $info->feature_id, $info);
+    // Repeat for grandchildren;.
+    if ($grand_children) {
+      foreach ($grand_children as $grand_child) {
+        $this->build_featureviewer_data($i, $grand_child);
+      }
+    }
+  }
+  /**
+   * Builds featureloc string for display to user.
+   *
+   * @param $featureloc
+   *   The featureloc object returned from chado_expand_var on featureloc.
+   *
+   * @return string
+   */
+  private function buildFeatureString($featureloc) {
+    $info = $featureloc->feature_id;
+    $min = $info->fmin ?? NULL;
+    $max = $info->fmax ?? NULL;
+    $strand = $info->strand ?? NULL;
+    $parent = $info->srcfeature_id->name ?? NULL;
+    if (!$min or !$max or !$strand) {
+      return 'No location available.';
+    }
+    $out = "${parent}:  ${min}-${max} (${strand})";
+    return $out;
+  }
+  /**
+   * Converts featureloc coordinates to be based on the entity.
+   *
+   * @param $i
+   * @param $feature_id
+   * @param $info
+   */
+  private function convertFeatureCoords($i, $feature_id, $info) {
+    $featureloc = $info->featureloc->feature_id;
+    // TODO: what if theres no featureloc relative to a parent?
+    $parent_start = $this->parent_start;
+    $parent_stop = $this->parent_stop;
+    $strand = $this->parent_strand;
+    $min = $featureloc->fmin ?? NULL;
+    $max = $featureloc->fmax ?? NULL;
+    $strand = $featureloc->strand ?? NULL;
+    if ($strand == '+') {
+      // It doesnt matter what strand it is, we always do this.
+      // TODO: check that assertion.
+      $start = $min - $parent_start + 1;
+      $stop = $max - $parent_start + 1;
+    }
+    else {
+      $start = $min - $parent_start + 1;
+      $stop = $max - $parent_start + 1;
+    }
+    $type = $info->type_id->name;
+    $color = $this->get_feature_color($type);
+    if (!isset($this->feature_coords[$i][$type])) {
+      $this->feature_coords[$i][$type] = [
+        'name' => $type,
+        'color' => $color,
+        'type' => 'rect',
+      ];
+    }
+    $this->feature_coords[$i][$type]['data'][] = [
+      'x' => $start,
+      'y' => $stop,
+      'description' => $info->uniquename,
+    ];
+  }
+  /**
+   * A color lookup to pass different colors to different feature subtypes.
+   *
+   * @param string $name
+   *   The feature type name.
+   *
+   * @return string
+   *   a hex color code.
+   */
+  private function get_feature_color(string $name) {
+    switch ($name) {
+      case 'mRNA':
+        return '#12E09D';
+      case 'polypeptide':
+        return '#808080';
+      case 'CDS':
+        return '#FF0000';
+      case 'exon':
+        return '#F4D4AD';
+      case NULL:
+        return '#000000';
+    }
+  }
+  /**
+   *
+   */
+  private function buildChildTable($child) {
+    $rows = [];
+    $children = $child['children'];
+    $mrna = $child['info'];
+    $sequence = $this->buildSequence($mrna);
+    $location = isset($mrna->featureloc) ? $this->buildFeatureString($mrna->featureloc) : 'Not available';
+    $rows[] = [
+      'Name' => $mrna->uniquename,
+      'Type' => $mrna->type_id->name,
+      'Sequence' => $sequence,
+      'Locations' => $location,
+    ];
+    foreach ($children as $gchild) {
+      $info = $gchild['info'];
+      $location = isset($info->featureloc) ? $this->buildFeatureString($info->featureloc) : 'Not available';
+      $sequence = $this->buildSequence($info);
+      $rows[] = [
+        'Name' => $info->uniquename,
+        'Type' => $info->type_id->name,
+        'Sequence' => $sequence,
+        'Locations' => $location,
+      ];
+      if (isset($gchild['children'])) {
+        $ggchild = $this->buildChildTable($gchild);
+        $rows = array_merge($rows, $ggchild);
+      }
+    }
+    return $rows;
+  }
+  /**
+   * @see ChadoFieldFormatter::settingsSummary()
+   **/
+  public function settingsSummary($view_mode) {
+    return '';
+  }
+  /**
+   * Build and display sequence for polypeptides and mRNA.
+   *
+   * @param $info
+   *
+   *   Info object.  @see \chado_generate_var().
+   *
+   * @return string
+   */
+  public function buildSequence($info) {
+    module_load_include('inc', 'popup', 'includes/popup.api');
+    $type = $info->type_id->name;
+    $out = '';
+    // Only display polypeptide, mRNA.
+    $check = ['polypeptide', 'mRNA', 'CDS'];
+    //might want to offer noncoding RNA?
+    if (!in_array($type, $check)) {
+      $out = 'N/A';
+      return $out;
+    }
+    $options = ['width' => 40, 'is_html' => 1];
+    // TODO: add in more options based on the sequence we're looking at.
+    // aggregate: Set to '1' if the sequence should only contain sub features, excluding intro sub feature sequence. For example, set this option to obtain just the coding sequence of an mRNA.
+    // sub_feature_types: Only include sub features (or child features) of the types provided in the array.
+    // TODO: I guess this should be done in the LOAD instead of the formatter?
+    $returned = chado_get_feature_sequences(['feature_id' => $info->feature_id], $options);
+    if (!$returned[0]['residues'] && $type === 'mRNA') {
+      $options['derive_from_parent'] = 1;
+      $returned = chado_get_feature_sequences(['feature_id' => $info->feature_id], $options);
+    }
+    foreach ($returned as $sequence) {
+      $seq_string = $sequence['residues'];
+      $header = $sequence['defline'] ?? $info->name;
+      $defline = '>' . $header . '<br>';
+      if ($seq_string) {
+        $out .= $defline . $seq_string;
+      }
+    }
+    if ($out) {
+      $container_id = 'popover-controller-' . $info->feature_id;
+      $id = 'popover-' . $info->feature_id;
+      $out = '
+      <a id="' . $container_id . '"data-target="' . $id . '" class="sequence-expand-trigger">Sequence</a>
+      <div style="display: none;" class="tripal-sequence-popover" id ="' . $id  . '"> ' . $out .  '</div>';
+    }
+    if (!$out) {
+      $out = 'Unavailable';
+    }
+    return $out;
+  }
+}

--- a/theme/js/tripal_manage_analyses_featureloc.js
+++ b/theme/js/tripal_manage_analyses_featureloc.js
@@ -33,15 +33,23 @@
         var mRNAInfo= [];
 
         var residues = features.residues
+        var parameters = features.parameters
         var children = features.children
-        var options = {
-            showAxis: true,
-            showSequence: true,
-            brushActive: true,
-            toolbar: true,
-            bubbleHelp: true,
-            zoomMax: 3
+
+        if (parameters) {
+            var options = parameters
         }
+        else {
+            var options = {
+                showAxis: true,
+                showSequence: true,
+                brushActive: true,
+                toolbar: true,
+                bubbleHelp: true,
+                zoomMax: 3
+            }
+        }
+
         Object.keys(children).forEach(function (key, index) {
             //Each child gets its own feature viewer
             var fv = new FeatureViewer(residues, "#tripal_manage_expression_featureloc_viewer_" + index, options);
@@ -56,13 +64,13 @@
 
         //  Now add master glyph
 
-        // var fv = new FeatureViewer(residues, "#tripal_manage_expression_featureloc_gene", options);
-        // var subFeatures = features.master
-        //
-        // Object.keys(subFeatures).forEach(function (sfKey, sfIndex) {
-        //     var subFeature = subFeatures[sfKey]
-        //     fv.addFeature(subFeature)
-        // })
+        var fv = new FeatureViewer(residues, "#tripal_manage_expression_featureloc_gene", options);
+        var subFeatures = features.master
+
+        Object.keys(subFeatures).forEach(function (sfKey, sfIndex) {
+            var subFeature = subFeatures[sfKey]
+            fv.addFeature(subFeature)
+        })
 
 
 

--- a/theme/js/tripal_manage_analyses_featureloc.js
+++ b/theme/js/tripal_manage_analyses_featureloc.js
@@ -33,27 +33,38 @@
         var mRNAInfo= [];
 
         var residues = features.residues
-        children = features.children
+        var children = features.children
+        var options = {
+            showAxis: true,
+            showSequence: true,
+            brushActive: true,
+            toolbar: true,
+            bubbleHelp: true,
+            zoomMax: 3
+        }
         Object.keys(children).forEach(function (key, index) {
             //Each child gets its own feature viewer
-            var options = {
-                showAxis: true,
-                showSequence: true,
-                brushActive: true,
-                toolbar: true,
-                bubbleHelp: true,
-                zoomMax: 3
-            }
-
-            var fv = new FeatureViewer(residues, '#tripal_manage_expression_featureloc_viewer_' + index, options);
-            subFeatures = children[key]
+            var fv = new FeatureViewer(residues, "#tripal_manage_expression_featureloc_viewer_" + index, options);
+            var subFeatures = children[key]
 
             Object.keys(subFeatures).forEach(function (sfKey, sfIndex) {
-                subFeature = subFeatures[sfKey]
+                var subFeature = subFeatures[sfKey]
                 fv.addFeature(subFeature)
 
             })
         })
+
+        //  Now add master glyph
+
+        // var fv = new FeatureViewer(residues, "#tripal_manage_expression_featureloc_gene", options);
+        // var subFeatures = features.master
+        //
+        // Object.keys(subFeatures).forEach(function (sfKey, sfIndex) {
+        //     var subFeature = subFeatures[sfKey]
+        //     fv.addFeature(subFeature)
+        // })
+
+
 
         // Trigger a window resize event to notify charting modules that
         // the container dimensions has changed

--- a/theme/js/tripal_manage_analyses_featureloc.js
+++ b/theme/js/tripal_manage_analyses_featureloc.js
@@ -9,7 +9,7 @@
              * JS to add the feature viewer.
              */
             tripal_manage_analyses_feature_viewers(settings.children_draw_info);
-            
+
             // Remove the jquery.ui override of our link theme:
             $(".ui-widget-content").removeClass('ui-widget-content')
 
@@ -29,6 +29,8 @@
      * Initializes the feature viewers on the page.
      */
     function tripal_manage_analyses_feature_viewers(features) {
+
+        var mRNAInfo= [];
 
         var residues = features.residues
         children = features.children


### PR DESCRIPTION
Make the gene glyph fields display in a more i5k specific desired way.
This means 

- "Glyph of glyphs" drawn with just mRNAs.
- each mRNA glyph now ecxcludes UTRs, polypeptide, and the mRNA location.   Instead, the mRNA is composed of its individual exons.
- all locations are now relative to the scaffold position.  This means the numbers in hte table match up to those on the drawing.  We offset the drawing to be the width of the gene.


![Screen Shot 2019-04-01 at 1 20 29 PM](https://user-images.githubusercontent.com/7063154/55346648-f5ece180-5480-11e9-9fd5-89c6b8a79950.png)


The old field is added as backup.

multiple transcripts will show up on the "main" glyph and you can click to expand a given gene feature:

![Screen Shot 2019-04-01 at 1 52 33 PM](https://user-images.githubusercontent.com/7063154/55348564-76addc80-5485-11e9-847a-d5ee1652d91a.png)
