### PR TITLE
obi__organism_linker fix for Issue 107

### DIFF
--- a/includes/TripalFields/obi__organism_linker/obi__organism_linker.inc
+++ b/includes/TripalFields/obi__organism_linker/obi__organism_linker.inc
@@ -101,7 +101,7 @@ class obi__organism_linker extends ChadoField {
 
     $record_id = $entity_record->$key;
     $sql = db_select('chado . organism', 'CO');
-    $sql->fields('CO', ['organism_id', 'common_name', 'abbreviation']);
+    $sql->fields('CO', ['organism_id', 'common_name', 'abbreviation', 'genus', 'species']);
     $sql->join($linker, 'CL', 'CL.organism_id = CO.organism_id');
     $sql->fields('CL', [$linker_key]);
     $sql->condition('CL.' . $field_column, $record_id);
@@ -113,6 +113,8 @@ class obi__organism_linker extends ChadoField {
     foreach ($results as $result) {
       $organism_abbreviation = $result->abbreviation;
       $organism_common_name = $result->common_name;
+      $organism_genus = $result->genus;
+      $organism_species = $result->species;
       $organism_record_id = $result->organism_id;
       $linker_record_id = $result->$linker_key;
 
@@ -124,6 +126,8 @@ class obi__organism_linker extends ChadoField {
             'entity_id' => $organism_entity_id,
             'common_name' => $organism_common_name,
             'abbreviation' => $organism_abbreviation,
+            'genus' => $organism_genus,
+            'species' => $organism_species,
             'organism_id' => $organism_record_id,
             'linker_record_id' => $linker_record_id,
           ],

--- a/includes/TripalFields/obi__organism_linker/obi__organism_linker_formatter.inc
+++ b/includes/TripalFields/obi__organism_linker/obi__organism_linker_formatter.inc
@@ -92,7 +92,20 @@ class obi__organism_linker_formatter extends ChadoFieldFormatter {
       if (!isset($organism["entity_id"])) {
         continue;
       }
-      $output = l("{$organism["abbreviation"]} ({$organism["common_name"]})", "bio_data/{$organism["entity_id"]}");
+      $displayname = $organism["abbreviation"];
+      if (!$displayname) {
+        if (function_exists('chado_get_organism_scientific_name')) {
+          $displayname = chado_get_organism_scientific_name(chado_get_organism(['organism_id' => $organism["organism_id"]], []));
+        }
+        else {
+          $displayname = $organism["genus"] . " " . $organism[$species];
+        }
+      }
+      if ($organism["common_name"]) {
+        $displayname .= " (${organism["common_name"]})";
+      }
+      $output = l($displayname, "bio_data/{$organism["entity_id"]}");
+      //$output = l("{$organism["abbreviation"]} ({$organism["common_name"]})", "bio_data/{$organism["entity_id"]}");
       $element[] = [
         '#type' => 'markup',
         '#markup' => $output,


### PR DESCRIPTION
Changes to the obi__organism_linker field for problems noted in issue #107 

The obi__organism_linker tripal field assumes both abbreviation and common_name both exist when formatting the displayed text. If they do not, it only displays a pair of parentheses, although the link works.

I am providing this pull request to use genus and species when these are not present, or call the chado_get_organism_scientific_name() function if it is available to get the full name including infraspecific nomenclature.