### PR TITLE
Suggested change to obi__organism_linker

### DIFF
--- a/includes/TripalFields/obi__organism_linker/obi__organism_linker.inc
+++ b/includes/TripalFields/obi__organism_linker/obi__organism_linker.inc
@@ -88,8 +88,8 @@ class obi__organism_linker extends ChadoField {
     }
     $pkey = $schema['primary key'][0];
 
-    $linker = 'chado.' . $base_table . '_organism';
-    $linker_key = $base_table . '_organism_id';
+    $linker = 'chado.' . $field_table;
+    $linker_key = $field_table . '_id';
     $fkey_lcolumn = key($schema['foreign keys'][$base_table]['columns']);
     $fkey_rcolumn = $schema['foreign keys'][$base_table]['columns'][$fkey_lcolumn];
 


### PR DESCRIPTION
I would like to use the ```obi__organism_linker``` field for other content types (tripal_file), but the field currently makes the assumption that the linker table is always named in the order ```sometable_organism```.
In some cases this is not true, it is ```organism_sometable```.
I have a suggested change to get the appropriate name from the ```$field_table``` value.
What do you think?