### PR TITLE
Issue 116 initialize with empty array

### DIFF
--- a/includes/TripalFields/data__sequence_features/data__sequence_features.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features.inc
@@ -135,6 +135,10 @@ class data__sequence_features extends ChadoField {
 
     $field = get_class($this);
 
+    // Set some defaults for the empty record.
+    $field_name = $this->field['field_name'];
+    $entity->{$field_name}['und'][0]['value'] = [];
+
     $parent = $entity->chado_record ? $entity->chado_record->feature_id : '';
 
     $children = $this->findChildFeatures($parent);

--- a/includes/TripalFields/data__sequence_features/data__sequence_features_widget.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features_widget.inc
@@ -24,7 +24,7 @@ class data__sequence_features_widget extends ChadoFieldWidget {
    * @see ChadoFieldWidget::form()
    **/
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+    // widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/data__sequence_features/data__sequence_features_widget.inc
+++ b/includes/TripalFields/data__sequence_features/data__sequence_features_widget.inc
@@ -24,7 +24,7 @@ class data__sequence_features_widget extends ChadoFieldWidget {
    * @see ChadoFieldWidget::form()
    **/
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    // widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+    // Widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/ero__nucleic_acid_library/ero__nucleic_acid_library.inc
+++ b/includes/TripalFields/ero__nucleic_acid_library/ero__nucleic_acid_library.inc
@@ -84,7 +84,7 @@ class ero__nucleic_acid_library extends ChadoField {
 
       // Go through the results and lookup the entity id of each.
       $output = [];
-      $entity->{$field_name}['und'][0]['value'] = NULL;
+      $entity->{$field_name}['und'][0]['value'] = [];
       $i = 0;
 
       foreach ($results as $result) {

--- a/includes/TripalFields/ero__nucleic_acid_library/ero__nucleic_acid_library.inc
+++ b/includes/TripalFields/ero__nucleic_acid_library/ero__nucleic_acid_library.inc
@@ -66,6 +66,10 @@ class ero__nucleic_acid_library extends ChadoField {
    */
   public function load($entity) {
 
+    // Set some defaults for the empty record.
+    $field_name = $this->field['field_name'];
+    $entity->{$field_name}['und'][0]['value'] = [];
+
     if ($entity->chado_table == 'organism') {
       // If its an organism, we dont have an organism_library linker table but an organism_id column in library.
       $field_name = $this->field['field_name'];

--- a/includes/TripalFields/ero__nucleic_acid_library/ero__nucleic_acid_library_widget.inc
+++ b/includes/TripalFields/ero__nucleic_acid_library/ero__nucleic_acid_library_widget.inc
@@ -76,7 +76,7 @@ class ero__nucleic_acid_library_widget extends ChadoFieldWidget {
    *    $delta above
    */
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+    // Widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/fbcv__gene_expression_profile/fbcv__gene_expression_profile.inc
+++ b/includes/TripalFields/fbcv__gene_expression_profile/fbcv__gene_expression_profile.inc
@@ -112,7 +112,7 @@ class fbcv__gene_expression_profile extends ChadoField {
     // additional data to be used in the display, you should add it here.
     parent::load($entity);
     $field = get_class($this);
-    $entity->{$field}['und'][0]['value'] = NULL;
+    $entity->{$field}['und'][0]['value'] = [];
 
     if ($entity->chado_table != 'organism') {
       return;

--- a/includes/TripalFields/fbcv__gene_expression_profile/fbcv__gene_expression_profile_widget.inc
+++ b/includes/TripalFields/fbcv__gene_expression_profile/fbcv__gene_expression_profile_widget.inc
@@ -22,7 +22,7 @@ class fbcv__gene_expression_profile_widget extends ChadoFieldWidget {
   **/
 
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+    // Widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/local__analysis_browser/local__analysis_browser.inc
+++ b/includes/TripalFields/local__analysis_browser/local__analysis_browser.inc
@@ -80,7 +80,7 @@ class local__analysis_browser extends ChadoField {
     $results = chado_query($sql, [
       ':organism_id' => $entity->chado_record->organism_id,
     ]);
-    $entity->{$field}['und'][0]['value'] = '';
+    $entity->{$field}['und'][0]['value'] = [];
 
     if (!$results) {
       return;

--- a/includes/TripalFields/local__analysis_browser/local__analysis_browser_widget.inc
+++ b/includes/TripalFields/local__analysis_browser/local__analysis_browser_widget.inc
@@ -72,7 +72,7 @@ class local__analysis_browser_widget extends ChadoFieldWidget {
    *    $delta above
    */
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+    // Widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/local__child_annotations/local__child_annotations.inc
+++ b/includes/TripalFields/local__child_annotations/local__child_annotations.inc
@@ -56,7 +56,7 @@ class local__child_annotations extends ChadoField {
     parent::load($entity);
     //  We should load in the data here.
     //  As a stopgap, we simply use the data loaded by the parent field in the formatter instead.
-    $entity->local__child_annotations['und'][0]['value'] = TRUE;
+    $entity->local__child_annotations['und'][0]['value'] = [];
 
   }
 

--- a/includes/TripalFields/local__child_annotations/local__child_annotations.inc
+++ b/includes/TripalFields/local__child_annotations/local__child_annotations.inc
@@ -56,7 +56,7 @@ class local__child_annotations extends ChadoField {
     parent::load($entity);
     //  We should load in the data here.
     //  As a stopgap, we simply use the data loaded by the parent field in the formatter instead.
-    $entity->local__child_annotations['und'][0]['value'] = [];
+    $entity->local__child_annotations['und'][0]['value'] = [TRUE];
 
   }
 

--- a/includes/TripalFields/local__child_annotations/local__child_annotations_widget.inc
+++ b/includes/TripalFields/local__child_annotations/local__child_annotations_widget.inc
@@ -21,6 +21,7 @@ class local__child_annotations_widget extends ChadoFieldWidget {
   **/
 
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+    // Widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/local__child_annotations/local__child_annotations_widget.inc
+++ b/includes/TripalFields/local__child_annotations/local__child_annotations_widget.inc
@@ -21,7 +21,6 @@ class local__child_annotations_widget extends ChadoFieldWidget {
   **/
 
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/local__child_properties/local__child_properties.inc
+++ b/includes/TripalFields/local__child_properties/local__child_properties.inc
@@ -133,7 +133,7 @@ class local__child_properties extends ChadoField {
 
     //  We should load in the data here.
     //  As a stopgap, we simply use the data loaded by the parent field in the formatter instead.
-    $entity->local__child_properties['und'][0]['value'] = [];
+    $entity->local__child_properties['und'][0]['value'] = [TRUE];
 
   }
 

--- a/includes/TripalFields/local__child_properties/local__child_properties.inc
+++ b/includes/TripalFields/local__child_properties/local__child_properties.inc
@@ -133,7 +133,7 @@ class local__child_properties extends ChadoField {
 
     //  We should load in the data here.
     //  As a stopgap, we simply use the data loaded by the parent field in the formatter instead.
-    $entity->local__child_properties['und'][0]['value'] = TRUE;
+    $entity->local__child_properties['und'][0]['value'] = [];
 
   }
 

--- a/includes/TripalFields/local__child_properties/local__child_properties_widget.inc
+++ b/includes/TripalFields/local__child_properties/local__child_properties_widget.inc
@@ -22,6 +22,7 @@ class local__child_properties_widget extends ChadoFieldWidget {
   **/
 
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+    // Widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/local__child_properties/local__child_properties_widget.inc
+++ b/includes/TripalFields/local__child_properties/local__child_properties_widget.inc
@@ -22,7 +22,6 @@ class local__child_properties_widget extends ChadoFieldWidget {
   **/
 
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/local__feature_analysis/local__feature_analysis_widget.inc
+++ b/includes/TripalFields/local__feature_analysis/local__feature_analysis_widget.inc
@@ -22,7 +22,6 @@ class local__feature_analysis_widget extends ChadoFieldWidget {
   **/
 
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/local__feature_analysis/local__feature_analysis_widget.inc
+++ b/includes/TripalFields/local__feature_analysis/local__feature_analysis_widget.inc
@@ -22,6 +22,7 @@ class local__feature_analysis_widget extends ChadoFieldWidget {
   **/
 
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+    // Widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/local__genome_browser/local__genome_browser.inc
+++ b/includes/TripalFields/local__genome_browser/local__genome_browser.inc
@@ -121,7 +121,7 @@ class local__genome_browser extends ChadoField {
     // additional data to be used in the display, you should add it here.
     parent::load($entity);
     $field = get_class($this);
-    $entity->{$field}['und'][0]['value'] = NULL;
+    $entity->{$field}['und'][0]['value'] = [];
 
     if ($entity->chado_table != 'organism') {
       return;

--- a/includes/TripalFields/local__genome_browser/local__genome_browser_widget.inc
+++ b/includes/TripalFields/local__genome_browser/local__genome_browser_widget.inc
@@ -76,7 +76,7 @@ class local__genome_browser_widget extends ChadoFieldWidget {
    *    $delta above
    */
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+    // Widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/local__phylotree_link/local__phylotree_link_widget.inc
+++ b/includes/TripalFields/local__phylotree_link/local__phylotree_link_widget.inc
@@ -22,7 +22,7 @@ class local__phylotree_link_widget extends ChadoFieldWidget {
   **/
 
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+    // Widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/local__transcriptome_viewer/local__transcriptome_viewer.inc
+++ b/includes/TripalFields/local__transcriptome_viewer/local__transcriptome_viewer.inc
@@ -115,7 +115,7 @@ class local__transcriptome_viewer extends ChadoField {
    */
   public function load($entity) {
     $field = get_class($this);
-    $entity->{$field}['und'][0]['value'] = NULL;
+    $entity->{$field}['und'][0]['value'] = [];
     if ($entity->chado_table != 'organism') {
       return;
     }

--- a/includes/TripalFields/local__transcriptome_viewer/local__transcriptome_viewer_widget.inc
+++ b/includes/TripalFields/local__transcriptome_viewer/local__transcriptome_viewer_widget.inc
@@ -76,7 +76,7 @@ class local__transcriptome_viewer_widget extends ChadoFieldWidget {
    *    $delta above
    */
   public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
-    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+    // Widget is not functional parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
   }
 
   /**

--- a/includes/TripalFields/obi__organism_linker/obi__organism_linker.inc
+++ b/includes/TripalFields/obi__organism_linker/obi__organism_linker.inc
@@ -82,14 +82,17 @@ class obi__organism_linker extends ChadoField {
     $base_table = $this->instance['settings']['base_table'];
     $key = $base_table . '_id';
 
+    // Set some defaults for the empty record.
+    $entity->{$field_name}['und'][0]['value'] = [];
+
     $schema = chado_get_schema($field_table);
     if (!$schema) {
       drupal_set_message(t('The organism linker field for ' . $field_table . ' is not present in the chado database!'));
     }
     $pkey = $schema['primary key'][0];
 
-    $linker = 'chado.' . $base_table . '_organism';
-    $linker_key = $base_table . '_organism_id';
+    $linker = 'chado.' . $field_table;
+    $linker_key = $field_table . '_id';
     $fkey_lcolumn = key($schema['foreign keys'][$base_table]['columns']);
     $fkey_rcolumn = $schema['foreign keys'][$base_table]['columns'][$fkey_lcolumn];
 


### PR DESCRIPTION
PHP8 related issue #116
Change all field initializations to use an empty array instead of NULL.
For consistency, one field that used an empty string is also changed to an empty array.